### PR TITLE
update NFT interface

### DIFF
--- a/src/Interface.mo
+++ b/src/Interface.mo
@@ -47,7 +47,7 @@ module {
         // Returns the account that is linked to the given token.
         bearer  : query (token : Ext.TokenIdentifier)            -> async Ext.NonFungible.BearerResponse;
         // Mints a new NFT and assignes its owner to the given User.
-        mintNFT : shared (request : Ext.NonFungible.MintRequest) -> async ();
+        mintNFT : shared (request : Ext.NonFungible.MintRequest) -> async Ext.TokenIdentifier;
 
         // [@ext:allowance]
 


### PR DESCRIPTION
I think the NonFungibleToken interface is missing one bit. mintNFT returns () in both Aviate-labs and Toniq labs interfaces. 
But in Toniq Labs implementation, they return TokenIndex. Which makes sense, since you otherwise, when you mint, you don't know the address of what you have just minted.
I suppose however, that its because they don't have TokenIdentifier.encode function. Returning the whole TokenIdentifier makes more sense.