### PR TITLE
add user to principal conversion method

### DIFF
--- a/src/Ext.mo
+++ b/src/Ext.mo
@@ -121,6 +121,13 @@ module {
                 };
             };
         };
+
+        public func toPrincipal(u : User) : ?Principal {
+            switch (u) {
+                case (#address(a)) null;
+                case (#principal(p)) ?p;
+            }
+        };
     };
 
     public module Core = {

--- a/src/Ext.mo
+++ b/src/Ext.mo
@@ -222,4 +222,13 @@ module {
             token      : TokenIdentifier;
         };
     };
+
+    public type NotifyService = actor {
+        tokenTransferNotification : shared (
+            token   : TokenIdentifier,
+            from    : User,
+            amount  : Balance,
+            memo    : Memo,
+        ) -> async ?Balance;
+    };
 };


### PR DESCRIPTION
## Proposed Changes

- Adds `Ext.User.toPrincipal(User) -> Principal`. Toniq labs' ext module exposes this mildly handy little method. It's sugary, but nice to have in the API.
- Adds `Ext.NotifyService` interface. EXT kinda supports transfer notifications, and this is the interface an actor needs to receive notifications.